### PR TITLE
netty dependency mixup : see https://datastax-oss.atlassian.net/brows…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,17 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+	<dependencies>
+		<!-- solves https://datastax-oss.atlassian.net/browse/JAVA-1018 -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
+			<version>4.0.27.Final</version>
+		</dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
With Achiles upgrade there was a change in the datastax cassandra driver:
netty's version in the driver causes cassandra embedded to fail.
netty dependency mixup : see https://datastax-oss.atlassian.net/browse/JAVA-1018
